### PR TITLE
Feature/v1 polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npx cdk deploy --all \
 |      Key      | Required |  Default  | Description |
 | ------------- | -------- | --------- | ----------- |
 | `domainName`     | x |               | The domain name for your static website. |
-| `region`         | x | `eu-north-1`  | The AWS region for the main stack (needs to be explicitly configured due to cross-region access). |
+| `region`         | x | `eu-north-1`  | The AWS region for the main stack. If not provided, the default value `eu-north-1` will be used. |
 | `hostedZoneId`   |   |               | The ID of the Route53 hosted zone for the domain. If not provided, will create a new hosted zone. |
 | `indexDocument`  |   | `index.html`  | The index document for the S3 bucket. |
 | `errorDocument`  |   |               | The error document for the S3 bucket. |

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ The application requires some context values for deployment:
 ```bash
 npx cdk deploy --all \
   --context domainName=yourdomain.com \
-  --context hostedZoneId=Z1234567890ABC \
   --context region=eu-north-1 \
+  --context hostedZoneId=Z1234567890ABC \
   --context indexDocument=index.html \
   --context errorDocument=error.html \
   --context deploymentPath=./dist
@@ -63,12 +63,14 @@ npx cdk deploy --all \
 
 ### Context Parameters
 
-- `domainName`: The domain name for your static website
-- `hostedZoneId`: The ID of the Route53 hosted zone for the domain
-- `region`: (Optional) The AWS region for the main stack (defaults to your configured AWS CLI region)
-- `indexDocument`: (Optional) The index document for the S3 bucket (default: index.html)
-- `errorDocument`: (Optional) The error document for the S3 bucket
-- `deploymentPath`: (Optional) The local path to the static site files to deploy (default: ./dist)
+|      Key      | Required |  Default  | Description |
+| ------------- | -------- | --------- | ----------- |
+| `domainName`     | x |               | The domain name for your static website. |
+| `region`         | x | `eu-north-1`  | The AWS region for the main stack (needs to be explicitly configured due to cross-region access). |
+| `hostedZoneId`   |   |               | The ID of the Route53 hosted zone for the domain. If not provided, will create a new hosted zone. |
+| `indexDocument`  |   | `index.html`  | The index document for the S3 bucket. |
+| `errorDocument`  |   |               | The error document for the S3 bucket. |
+| `deploymentPath` |   |               | The local path to the static site files to deploy. If not provided, no files will be uploaded and you have to manage them manually. |
 
 ## Customization Options
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ npx cdk deploy --all \
 The StaticPageCdkStack can be customized through props and context:
 
 - **certificateArn**: Pass a custom certificate ARN instead of using the CertificateStack
-- **priceClass**: CloudFront is configured to use PRICE_CLASS_100 (US, Canada, Europe) by default
-- **bucketName**: The S3 bucket is named based on the domain name (`${domainName}-static-page`)
 
 ## CloudFormation Outputs
 

--- a/bin/static-page-cdk.ts
+++ b/bin/static-page-cdk.ts
@@ -7,20 +7,20 @@ import { CertificateStack } from '../lib/certificate-stack';
 const app = new cdk.App();
 
 const domainName = app.node.tryGetContext('domainName');
-const hostedZoneId = app.node.tryGetContext('hostedZoneId');
+const region = app.node.tryGetContext('region') || 'eu-north-1';
 
-if (!domainName || !hostedZoneId) {
-  throw new Error('Domain name and hosted zone ID must be provided in the context');
+if (!domainName || !region) {
+  throw new Error('Domain name and region must be provided in the context');
 }
 
 const certificateStack = new CertificateStack(app, 'StaticPageCertificateStack', {
   domainName,
-  hostedZoneId
+  hostedZoneId: app.node.tryGetContext('hostedZoneId')
 });
 
 // Create the main stack (can be in any region)
 const mainStack = new StaticPageCdkStack(app, 'StaticPageCdkStack', {
-  env: app.node.tryGetContext('region') ? { region: app.node.tryGetContext('region') } : undefined,
+  env: { region },
   crossRegionReferences: true,
   certificateArn: certificateStack.certificate.certificateArn
 });

--- a/lib/static-page-cdk-stack.ts
+++ b/lib/static-page-cdk-stack.ts
@@ -1,7 +1,7 @@
 import { AllowedMethods, Distribution, PriceClass, ViewerProtocolPolicy } from 'aws-cdk-lib/aws-cloudfront';
 import { S3BucketOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import { BlockPublicAccess, Bucket } from 'aws-cdk-lib/aws-s3';
-import { ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
+import { ARecord, HostedZone, IHostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
 import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
 import { Construct } from 'constructs';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
@@ -22,13 +22,21 @@ export class StaticPageCdkStack extends Stack {
     }
 
     const hostedZoneId: string | undefined = this.node.tryGetContext('hostedZoneId');
+    let hostedZone: IHostedZone | undefined;
     if (!hostedZoneId) {
-      throw new Error('Hosted zone ID must be provided in the context');
+      hostedZone = new HostedZone(this, 'StaticPageHostedZone', {
+        zoneName: domainName,
+      });
+    } else {
+      hostedZone = HostedZone.fromHostedZoneAttributes(this, 'ImportedHostedZone', {
+        hostedZoneId,
+        zoneName: domainName,
+      });
     }
 
     const errorDocument: string | undefined = this.node.tryGetContext('errorDocument');
     const indexDocument: string = this.node.tryGetContext('indexDocument') ?? 'index.html';
-    const deploymentPath: string = this.node.tryGetContext('deploymentPath') ?? './dist';
+    const deploymentPath: string | undefined = this.node.tryGetContext('deploymentPath');
 
     let certificateArn = props?.certificateArn;
 
@@ -44,11 +52,6 @@ export class StaticPageCdkStack extends Stack {
     new CfnOutput(this, 'BucketName', {
       value: s3Bucket.bucketName,
       description: 'The name of the S3 bucket for the static page',
-    });
-
-    const hostedZone = HostedZone.fromHostedZoneAttributes(this, 'ImportedHostedZone', {
-      hostedZoneId,
-      zoneName: domainName,
     });
 
     const distribution = new Distribution(this, 'StaticPageDistribution', {
@@ -69,12 +72,14 @@ export class StaticPageCdkStack extends Stack {
       description: 'The ID of the CloudFront distribution',
     });
 
-    new BucketDeployment(this, 'DeployStaticWebsite', {
-      sources: [Source.asset(deploymentPath)],
-      destinationBucket: s3Bucket,
-      distribution,
-      distributionPaths: ['/*'],
-    });
+    if (deploymentPath) {
+      new BucketDeployment(this, 'DeployStaticWebsite', {
+        sources: [Source.asset(deploymentPath)],
+        destinationBucket: s3Bucket,
+        distribution,
+        distributionPaths: ['/*'],
+      });
+    }
   
     if (certificateArn) {
       new ARecord(this, 'SiteAliasRecord', {

--- a/lib/static-page-cdk-stack.ts
+++ b/lib/static-page-cdk-stack.ts
@@ -22,7 +22,7 @@ export class StaticPageCdkStack extends Stack {
     }
 
     const hostedZoneId: string | undefined = this.node.tryGetContext('hostedZoneId');
-    let hostedZone: IHostedZone | undefined;
+    let hostedZone: IHostedZone;
     if (!hostedZoneId) {
       hostedZone = new HostedZone(this, 'StaticPageHostedZone', {
         zoneName: domainName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "static-page-cdk",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "bin": {
     "static-page-cdk": "bin/static-page-cdk.js"
   },


### PR DESCRIPTION
This pull request introduces significant updates to the `StaticPageCdkStack` implementation and its documentation. The changes improve flexibility in handling hosted zones, make deployment path optional, and enhance the clarity of context parameters in the `README.md`. Below are the most important changes grouped by theme:

### Documentation Updates:
- **Context Parameters Table**: Replaced the bullet-point list of context parameters in `README.md` with a structured table format, providing clearer descriptions and default values for each parameter. Notably, the `hostedZoneId` is now optional, and its absence will trigger the creation of a new hosted zone.

### Hosted Zone Handling:
- **Dynamic Hosted Zone Creation**: Modified the hosted zone logic in `StaticPageCdkStack` to dynamically create a new hosted zone if `hostedZoneId` is not provided in the context. This eliminates the previous requirement to manually specify a hosted zone ID. [[1]](diffhunk://#diff-257746e07143dd673494aec73c77c3949453f3a755ab18a531e0c097e5770688R25-R39) [[2]](diffhunk://#diff-257746e07143dd673494aec73c77c3949453f3a755ab18a531e0c097e5770688L49-L53)
- **Type Update for Hosted Zone**: Updated the type of `hostedZone` to `IHostedZone` to support both newly created and imported hosted zones.

### Deployment Path Flexibility:
- **Optional Deployment Path**: Made the `deploymentPath` context parameter optional. If not provided, the deployment process will skip uploading static site files to the S3 bucket. Added a conditional check to ensure `BucketDeployment` is only executed when `deploymentPath` is defined. [[1]](diffhunk://#diff-257746e07143dd673494aec73c77c3949453f3a755ab18a531e0c097e5770688R25-R39) [[2]](diffhunk://#diff-257746e07143dd673494aec73c77c3949453f3a755ab18a531e0c097e5770688R75-R82)